### PR TITLE
fix: LCP・メタ情報・robots.txt を改善

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -89,4 +89,8 @@ SEO 改善・デザイン刷新・ブログ要素強化を一括実施。その�
 | 2026-08-09 | 本文リンクの視認性 | `a { color: inherit; text-decoration: none }` により本文中のリンクが本文と同色・下線なしで、`↗` 以外に手がかりがなかった。`main a` に限りアクセント色 + 下線を付与 (ヘッダー・フッターは位置で自明なため対象外)。あわせて `:focus-visible` のフォーカスリングを追加 |
 | 2026-08-09 | 日本語組版 | `line-break: strict` (禁則処理強化) と `overflow-wrap: anywhere` を body に、見出しに `text-wrap: balance`、段落に `text-wrap: pretty` を適用。いずれも progressive enhancement で非対応ブラウザでも破綻しない |
 | 2026-08-09 | OGP 画像 | 共有時にテキストしか出なかったため 1200×630 の `public/og-image.png` を追加し `twitter:card` を `summary_large_image` に変更。画像は profile.jpg + Noto Sans JP で生成 (Pillow、生成スクリプトはリポジトリ管理外) |
+| 2026-08-09 | LCP 改善 | プロフィール画像はファーストビュー内にあるのに `loading="lazy"` が付いていたため `eager` + `fetchpriority="high"` に変更。あわせて内在サイズを 200→240px に (CSS 表示 120px の 2x 相当) |
+| 2026-08-09 | 画像の alt | 英語の `"iokira's profile picture"` から日本語の説明に変更。画像の実体はコーヒー豆なのでその旨を記述 |
+| 2026-08-09 | robots.txt | `Sitemap:` ディレクティブが無かったため追加 |
+| 2026-08-09 | メタ情報の補完 | `theme-color` (ライト/ダーク別)、`og:site_name`、`twitter:creator` を追加 |
 | 2026-08-09 | 構造化データ | 人物として同定させるため `Person` schema の JSON-LD を追加。`sameAs` で GitHub / X を束ね、資格一覧は既存の `qualifications` 配列から `hasCredential` を生成。SNS リンクには `rel="me"` を付与。生年・出身地はプライバシー上の判断で意図的に含めていない |

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://iokira.net/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ interface Props {
 
 const { pageTitle, description, ogType, structuredData } = Astro.props;
 const siteTitle = "iokira.net";
+const twitterHandle = "@iokira_jp";
 const title =
     pageTitle === siteTitle ? siteTitle : `${pageTitle} | ${siteTitle}`;
 const metaDescription =
@@ -35,6 +36,16 @@ const ogImageURL = new URL("/og-image.png", Astro.site);
         <meta
             name="color-scheme"
             content="light dark"
+        />
+        <meta
+            name="theme-color"
+            media="(prefers-color-scheme: light)"
+            content="#ffffff"
+        />
+        <meta
+            name="theme-color"
+            media="(prefers-color-scheme: dark)"
+            content="#111827"
         />
         <title>{title}</title>
         <meta
@@ -66,6 +77,10 @@ const ogImageURL = new URL("/og-image.png", Astro.site);
         <meta
             property="og:locale"
             content="ja_JP"
+        />
+        <meta
+            property="og:site_name"
+            content={siteTitle}
         />
         <meta
             property="og:image"
@@ -100,6 +115,10 @@ const ogImageURL = new URL("/og-image.png", Astro.site);
         <meta
             name="twitter:image"
             content={ogImageURL}
+        />
+        <meta
+            name="twitter:creator"
+            content={twitterHandle}
         />
 
         <!-- Favicon -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,9 +76,11 @@ const structuredData = {
         <Image
             class="profile-image"
             src={profileImage}
-            alt="iokira's profile picture"
-            width={200}
-            height={200}
+            alt="プロフィール画像: 焙煎されたコーヒー豆"
+            width={240}
+            height={240}
+            loading="eager"
+            fetchpriority="high"
         />
     </div>
     <h2>Bio</h2>


### PR DESCRIPTION
## Summary

判断不要で進められる機械的な改善をまとめて実施。

### LCP (画像読み込み)

プロフィール画像はファーストビュー内 (`main` の最初の要素) にあるのに、Astro の既定で `loading="lazy" fetchpriority="auto"` が付いていた。LCP 候補の画像を遅延読み込みするのは逆効果なので `eager` + `fetchpriority="high"` に変更。

あわせて内在サイズを 200→240px に。CSS 表示は 120px なので 2x ディスプレイでは 240px 必要で、従来はわずかに解像度不足だった (生成 webp は 10kB → 14kB)。

```diff
-alt="iokira's profile picture" width={200} height={200}
+alt="プロフィール画像: 焙煎されたコーヒー豆" width={240} height={240}
+loading="eager" fetchpriority="high"
```

### alt テキスト

日本語ページに英語の alt が付いていたため日本語化。画像の実体はコーヒー豆なので、その内容がわかる記述にした。

### robots.txt

`Sitemap:` ディレクティブが無かったため追加。生成される `sitemap-index.xml` のパスと一致することを確認済み。

### メタ情報の補完

- `theme-color` — ライト `#ffffff` / ダーク `#111827` を `media` 属性で出し分け
- `og:site_name`
- `twitter:creator` (`@iokira_jp`)

## Test plan

- [x] `npm run build` 成功
- [x] ビルド後の `<img>` が `loading="eager" fetchpriority="high" width="240" height="240"` になることを確認
- [x] 追加した 4 つの meta がビルド後の HTML に出力されることを確認
- [x] `robots.txt` の Sitemap URL が実際に生成される `dist/sitemap-index.xml` と一致することを確認
- [x] `npx prettier --check` 通過

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCM7eW8p7GS8U9XmqEgGgq)_